### PR TITLE
Fixed utf-8 error in from line

### DIFF
--- a/email_parser.py
+++ b/email_parser.py
@@ -26,7 +26,7 @@ class Email(object):
         for item in msg.items():
             if item[0] == 'From':
                 parsed_address = email.utils.parseaddr(item[1])
-                self.name = parsed_address[0]
+                self.name, encoding = email.Header.decode_header(parsed_address[0])[0]
                 self.address = parsed_address[1]
             if item[0] == 'Date':
                 self.date = strftime('%d %B %Y',email.utils.parsedate(item[1]))


### PR DESCRIPTION
Modified one line in order to properly decode the utf-8 error that was occuring in the "name" box in the csv file for certain entries. Using the same fix on the similar "subject" line utf-8 error works but produces a new error that I am still working on.
